### PR TITLE
docs(readme): updating README.md with golangci-lint info

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,20 @@ type Client struct {
 
 ## ⬇️  Getting Started
 
-Install it by running:
+### As a golangci-lint linter
+
+Enable the linter in your golangci-lint configuration file, e.g:
+
+```yaml
+linters:
+  enable:
+    - embeddedstructfieldcheck 
+    ...
+```
+
+### Standalone application
+
+Install EmbeddedStructFieldCheck by running:
 
 ```bash
 go install github.com/manuelarte/embeddedstructfieldcheck@latest


### PR DESCRIPTION
Updating README.md with info on how to use the liner in golangci-lint.