### PR TITLE
fix: do not check emtpy line when there are comments in between

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"go/ast"
+	"slices"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -50,15 +51,43 @@ func run(pass *analysis.Pass, emptyLine, forbidMutex bool) {
 	}
 
 	nodeFilter := []ast.Node{
-		(*ast.StructType)(nil),
+		new(ast.File),
+		new(ast.StructType),
 	}
 
-	insp.Preorder(nodeFilter, func(n ast.Node) {
-		node, ok := n.(*ast.StructType)
-		if !ok {
-			return
-		}
+	var fileComments []*ast.CommentGroup
 
-		internal.Analyze(pass, node, emptyLine, forbidMutex)
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		switch n := n.(type) {
+		case *ast.File:
+			fileComments = n.Comments
+		case *ast.StructType:
+			fieldComments := make([]*ast.CommentGroup, 0, len(getFields(n.Fields)))
+			for _, field := range getFields(n.Fields) {
+				if field.Doc == nil {
+					continue
+				}
+
+				fieldComments = append(fieldComments, field.Doc)
+			}
+
+			insideStructNotAttachedComments := make([]*ast.CommentGroup, 0)
+
+			for _, cg := range fileComments {
+				if cg.Pos() > n.Pos() && cg.End() < n.End() && !slices.Contains(fieldComments, cg) {
+					insideStructNotAttachedComments = append(insideStructNotAttachedComments, cg)
+				}
+			}
+
+			internal.Analyze(pass, n, emptyLine, forbidMutex, insideStructNotAttachedComments)
+		}
 	})
+}
+
+func getFields(fl *ast.FieldList) []*ast.Field {
+	if fl == nil {
+		return nil
+	}
+
+	return fl.List
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -104,7 +104,7 @@ func TestAnalyzerWithFix(t *testing.T) {
 			desc:     "block comments (disabling empty-line)",
 			patterns: "block-comments",
 			options: map[string]string{
-				EmptyLineCheck:   "false",
+				EmptyLineCheck:   "true",
 				ForbidMutexCheck: "false",
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/manuelarte/embeddedstructfieldcheck
 
 go 1.25.0
 
-require golang.org/x/tools v0.46.0
+require golang.org/x/tools v0.47.0
 
 require (
 	golang.org/x/mod v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/tools v0.46.0 h1:7jTurBkPZu4moS/Uy4OQT1M+QBlsj3wejyZwsT8Z7rk=
-golang.org/x/tools v0.46.0/go.mod h1:FrD85F8l+NWL+9XWBSyVSHO6Ne4jutsfIFba7AWQ5Ys=
+golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=

--- a/internal/structanalyzer.go
+++ b/internal/structanalyzer.go
@@ -6,7 +6,12 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-func Analyze(pass *analysis.Pass, st *ast.StructType, emptyLine, forbidMutex bool) {
+func Analyze(
+	pass *analysis.Pass,
+	st *ast.StructType,
+	emptyLine, forbidMutex bool,
+	separatedComments []*ast.CommentGroup,
+) {
 	var firstEmbeddedField *ast.Field
 
 	var lastEmbeddedField *ast.Field
@@ -35,7 +40,7 @@ func Analyze(pass *analysis.Pass, st *ast.StructType, emptyLine, forbidMutex boo
 	}
 
 	if emptyLine {
-		checkMissingSpace(pass, lastEmbeddedField, firstNotEmbeddedField)
+		checkMissingSpace(pass, lastEmbeddedField, firstNotEmbeddedField, separatedComments)
 	}
 }
 
@@ -55,8 +60,20 @@ func checkForbiddenEmbeddedField(pass *analysis.Pass, field *ast.Field, forbidMu
 	}
 }
 
-func checkMissingSpace(pass *analysis.Pass, lastEmbeddedField, firstNotEmbeddedField *ast.Field) {
+func checkMissingSpace(
+	pass *analysis.Pass,
+	lastEmbeddedField, firstNotEmbeddedField *ast.Field,
+	separatedComments []*ast.CommentGroup,
+) {
 	if lastEmbeddedField != nil && firstNotEmbeddedField != nil {
+		commentInBetween := findCommentInBetweenNotBelongingToAField(
+			pass, lastEmbeddedField, firstNotEmbeddedField, separatedComments,
+		)
+		if commentInBetween != nil {
+			// do not check if there is a comment in between not assigned to any field
+			return
+		}
+
 		// check for missing space
 		// TODO: isn't it easy to remove as many lines as comments between last embedded type and first not embedded
 		line := pass.Fset.Position(lastEmbeddedField.End()).Line
@@ -85,4 +102,25 @@ func reportSyncMutex(pass *analysis.Pass, se *ast.SelectorExpr) {
 	if packageName.Name == "sync" && (se.Sel.Name == "Mutex" || se.Sel.Name == "RWMutex") {
 		pass.Report(NewForbiddenEmbeddedFieldDiag(se))
 	}
+}
+
+func findCommentInBetweenNotBelongingToAField(
+	pass *analysis.Pass,
+	lastEmbeddedField, firstNotEmbeddedField *ast.Field,
+	separatedComments []*ast.CommentGroup,
+) *ast.CommentGroup {
+	for _, cg := range separatedComments {
+		if cg.Pos() <= lastEmbeddedField.Pos() || cg.End() >= firstNotEmbeddedField.Pos() {
+			continue
+		}
+
+		// not inlined comment
+		if pass.Fset.Position(cg.Pos()).Line == pass.Fset.Position(lastEmbeddedField.Pos()).Line {
+			continue
+		}
+
+		return cg
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #21 

### Have you included tests for your changes?

I updated the already existing test.

### Did you document any new/modified functionality?

- [x] Updated `testdata/`.
- [ ] Updated `README.md`.
- [x] Documented new cli option (if applicable).

### Notes

This PR solves the potential issue of linting about the empty line missing between last embedded field and the first non-embedded field when there is a comment in between.

@ldez what do you think? is this a good approach? or maybe it's simple to check that the number of empty lines between the two fields is more than 1 then that case should not be checked (since the own go formatting would prevent that), meaning that, that's because there is a comment block in between?  